### PR TITLE
Revert "Don't echo message on BYE" (Closes: #7)

### DIFF
--- a/anypinentry
+++ b/anypinentry
@@ -157,7 +157,7 @@ interpret_command() {
     NOP)              ;;
     CANCEL)           not_implemented_error ;;
     OPTION)           save_option "$data" ;;
-    BYE)              exit 0 ;;
+    BYE)              echo "OK closing connection"; exit 0 ;;
     AUTH)             not_implemented_error ;;
     RESET)            reset ;;
     END)              not_implemented_error ;;


### PR DESCRIPTION
This follows the spec and what other pinentry implementation do.

This reverts commit 4f5ed2ab1256af9b41a94091cdea5cf7c2eaa341.