### PR TITLE
fix input parsing when cmd has no data

### DIFF
--- a/anypinentry
+++ b/anypinentry
@@ -151,7 +151,7 @@ interpret_command() {
     return
   fi
   cmd="$(echo "$1" | cut -d' ' -f1 | tr a-z A-Z)";
-  data="$(echo "$1" | cut -d' ' -f2-)";
+  data="$(echo "$1" | cut -d' ' -sf2-)";
 
   case "${cmd}" in
     NOP)              ;;


### PR DESCRIPTION
When a command has no arguments it is expected that $cmd equals the command and $data is null, but the way the cut command is written makes it so $data also equals the command.

For example, doing SETREPEAT with no arg is expected to default to "repeat" but instead when running GETPIN, the prompt for the repeat is the same as the command, i.e. "SETREPEAT".

Fixed it by adding the -s option to cut.