### PR TITLE
posix compliance: replace `echo -e`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ The following variables inside `./anypinentry` script file can be configured.
 You will need to use `AP_PROMPT`, `AP_YES`, `AP_NO`, `AP_ERROR` variables inside your actions.
 
 * `prompt_action` - Action to show a prompt asking for password (Example using dmenu with password patch - `dmenu -P -p "$AP_PROMPT"`)
-* `confirm_action` - Action to confirm something (YES or NO) (Example with dmenu - `echo -e "$AP_YES\n$AP_NO" | dmenu -p "$AP_PROMPT"`)
+* `confirm_action` - Action to confirm something (YES or NO) (Example with dmenu - `printf "%s\n%s" "$AP_YES" "$AP_NO" | dmenu -p "$AP_PROMPT"`)
 * `display_error_action` - Action to display error messages to user (Example with notify-send - `notify-send "$AP_ERROR"`)

--- a/anypinentry
+++ b/anypinentry
@@ -22,7 +22,7 @@ AP_YES="Yes";
 AP_NO="No";
 
 prompt_action='dmenu -P -p "$AP_PROMPT"';
-confirm_action='echo -e "$AP_YES\n$AP_NO" | dmenu -p "$AP_PROMPT"';
+confirm_action='printf "%s\n%s\n" "$AP_YES" "$AP_NO" | dmenu -p "$AP_PROMPT"';
 display_error_action='notify-send -a "Pinentry" "$AP_ERROR"';
 
 # :: Prompt string (default if empty)
@@ -212,7 +212,7 @@ Options:
 CMD will be executed by sh(1). The defaults are:
 
 prompt ='dmenu -P -p "$prompt_string"';
-confirm ='echo -e "$AP_YES\n$AP_NO" | dmenu -p "$prompt_string"';
+confirm ='printf "%s\n%s\n" "$AP_YES" "$AP_NO" | dmenu -p "$prompt_string"';
 error-command ='notify-send -a "Pinentry" "$error__password_mismatch"';
 
 Standard pinentry options

--- a/anypinentry
+++ b/anypinentry
@@ -22,7 +22,7 @@ AP_YES="Yes";
 AP_NO="No";
 
 prompt_action='dmenu -P -p "$AP_PROMPT"';
-confirm_action='printf "%s\n%s\n" "$AP_YES" "$AP_NO" | dmenu -p "$AP_PROMPT"';
+confirm_action='printf "%s\n%s" "$AP_YES" "$AP_NO" | dmenu -p "$AP_PROMPT"';
 display_error_action='notify-send -a "Pinentry" "$AP_ERROR"';
 
 # :: Prompt string (default if empty)
@@ -212,7 +212,7 @@ Options:
 CMD will be executed by sh(1). The defaults are:
 
 prompt ='dmenu -P -p "$prompt_string"';
-confirm ='printf "%s\n%s\n" "$AP_YES" "$AP_NO" | dmenu -p "$prompt_string"';
+confirm ='printf "%s\n%s" "$AP_YES" "$AP_NO" | dmenu -p "$prompt_string"';
 error-command ='notify-send -a "Pinentry" "$error__password_mismatch"';
 
 Standard pinentry options


### PR DESCRIPTION
Running CONFIRM when /bin/sh is dash results in the string "-e Yes" being passed to dmenu, since echo -e is not POSIX compliant.

Replaced it with printf.