### PR TITLE
implement SETERROR

### DIFF
--- a/anypinentry
+++ b/anypinentry
@@ -13,6 +13,7 @@ prompt_string_default="PIN: "
 
 title="";
 prompt_string="$prompt_string_default";
+error_string="";
 description="";
 keyinfo="";
 repeat="";
@@ -27,7 +28,7 @@ display_error_action='notify-send -a "Pinentry" "$AP_ERROR"';
 
 # :: Prompt string (default if empty)
 ask_password() {
-  export AP_PROMPT="${1:-"$prompt_string"}";
+  export AP_PROMPT="${error_string}${1:-"$prompt_string"}";
   printf '' | sh -c "$prompt_action" 2> /dev/null;
 }
 # :: Prompt string (default if empty)
@@ -51,6 +52,7 @@ unknown_error() { echo "ERR 536871187 Unknown IPC command <User defined source 1
 reset() {
     description= 
     prompt_string="$prompt_string_default" 
+    error_string= 
     keyinfo= 
     repeat= 
     error__password_mismatch= 
@@ -100,6 +102,7 @@ password_prompt() {
     cancelled_error;
   fi;
   repeat=
+  error_string=
 }
 
 # :: OK | ERR
@@ -109,6 +112,7 @@ confirm_prompt() {
   else
     cancelled_error;
   fi
+  error_string=
 }
 
 pinentry_help() {
@@ -167,7 +171,7 @@ interpret_command() {
     SETKEYINFO)       keyinfo="$data"; echo "OK" ;;
     SETREPEAT)        repeat="${data:-"repeat"}"; echo "OK" ;;
     SETREPEATERROR)   error__password_mismatch="$data"; echo "OK" ;;
-    SETERROR)         not_implemented_error ;;
+    SETERROR)         error_string="[$data] "; echo "OK" ;;
     SETOK)            setok="$data" ;;
     SETNOTOK)         setnotok="$data" ;;
     SETCANCEL)        setcancel="$data" ;;


### PR DESCRIPTION
Stores the argument to SETERROR in a variable ($error_string) which gets prepended to the prompt.

Without this patch gpg simply aborts when you type the wrong password instead of prompting again with an error message, so if for whatever reason you don't feel like accepting this, at least consider just returning an OK instead of a not implemented error.

I made it clear up $error_string after prompting for PIN or for confirmation, trying to mimic what I found by playing around a bit with the pinentry-qt implementation. Feel free to come up with a better (more compliant?) solution.